### PR TITLE
Use tidy eval with colpair_map()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # corrr (development version)
 
+- Make `colpair_map()` more robust to input column names, with the exception of ".data" and ".env" (@jameslairdsmith, #131).
+
 # corrr 0.4.3
 
 - Fix EOL issues and class attribute (@krlmlr, #93 and #90)

--- a/R/colpair.R
+++ b/R/colpair.R
@@ -1,7 +1,7 @@
 #' Apply a function to all pairs of columns in a data frame
 #'
 #' `colpair_map()` transforms a data frame by applying a function to each pair
-#'   of its columns.The result is a correlation data frame (see
+#'   of its columns. The result is a correlation data frame (see
 #'   \code{\link{correlate}} for details).
 #'
 #' @param .data A data frame or data frame extension (e.g. a tibble).

--- a/R/colpair.R
+++ b/R/colpair.R
@@ -26,7 +26,11 @@
 
 colpair_map <- function(.data, .f, ..., .diagonal = NA){
 
+  ## .data cannot be used as column name.
+
   out <- purrr::map_dfr(.data, summarise_col, {{ .f }}, .data, ...)
+
+  ## Tidy eval curly brackets ({{) are for compatibility with dplyr v1.0.0 - v1.0.3
 
   as_cordf(out, diagonal = .diagonal)
 
@@ -50,4 +54,6 @@ summarise_col <- function(.x, .f, .data, ...){
                                        .fns = {{ .f }},
                                        {{ .x }},
                                        ...))
+
+  ## Tidy eval curly brackets ({{) are for compatibility with dplyr v1.0.0 - v1.0.3
 }

--- a/R/colpair.R
+++ b/R/colpair.R
@@ -26,7 +26,7 @@
 
 colpair_map <- function(.data, .f, ..., .diagonal = NA){
 
-  out <- purrr::map_dfr(.data, summarise_col, .f, .data, ...)
+  out <- purrr::map_dfr(.data, summarise_col, {{ .f }}, .data, ...)
 
   as_cordf(out, diagonal = .diagonal)
 
@@ -44,10 +44,10 @@ colpair_map <- function(.data, .f, ..., .diagonal = NA){
 #'
 #' @noRd
 
-summarise_col <- function(.data_col, f, .data, ...){
+summarise_col <- function(x, f, data, ...){
 
-  dplyr::summarise(.data, dplyr::across(.cols = dplyr::everything(),
-                                        .fns = f,
-                                        .data_col,
+  dplyr::summarise(data, dplyr::across(.cols = dplyr::everything(),
+                                       .fns = {{ f }},
+                                       {{ x }},
                                        ...))
 }

--- a/man/colpair_map.Rd
+++ b/man/colpair_map.Rd
@@ -20,7 +20,7 @@ A correlation data frame (\code{cor_df}).
 }
 \description{
 \code{colpair_map()} transforms a data frame by applying a function to each pair
-of its columns.The result is a correlation data frame (see
+of its columns. The result is a correlation data frame (see
 \code{\link{correlate}} for details).
 }
 \examples{

--- a/tests/testthat/test-colpair.R
+++ b/tests/testthat/test-colpair.R
@@ -10,3 +10,16 @@ test_that("colpair_map() works", {
                tolerance = 0.0001)
   expect_equal(correlate(mtcars), colpair_map(mtcars, cor))
 })
+
+test_that("colpair_map() masks argument names", {
+
+  arg_names <- c("x", ".x", "f", ".f" , ".fns", "data", ".data",
+                 "summarise_col", ".cols", "diagonal", ".diagonal")
+
+  my_mtcars <- mtcars
+  colnames(my_mtcars) <- arg_names
+
+  expect_equal(colpair_map(my_mtcars, cor),
+               correlate(my_mtcars, quiet = TRUE),
+               tolerance = 1e-10)
+})

--- a/tests/testthat/test-colpair.R
+++ b/tests/testthat/test-colpair.R
@@ -13,8 +13,10 @@ test_that("colpair_map() works", {
 
 test_that("colpair_map() masks argument names", {
 
-  arg_names <- c("x", ".x", "f", ".f" , ".fns", "data", ".data",
+  arg_names <- c("x", ".x", "f", ".f" , ".fns", "data", ".data2",
                  "summarise_col", ".cols", "diagonal", ".diagonal")
+
+  ## `.data` is an exception: users cannot use it as a column name.
 
   my_mtcars <- mtcars
   colnames(my_mtcars) <- arg_names


### PR DESCRIPTION
#127 pointed out that `colpair_map()` behaves incorrectly when one of the columns has names that are the same as the those of the function's (underlying) arguments. The example given was with a column called `x`. The fix since made in #129 is helpful: it makes a problem much less likely by renaming that argument `x` to `.data_col` and the `data` argument of the helper function to `.data`.

But the function still fails if a column is named `f`:

``` r
# devtools::install_github("tidymodels/corrr") 
library(dplyr, warn.conflicts = F)
library(corrr)

mtcars %>% 
  rename(f = mpg) %>% 
  colpair_map(cor)
#> Error: Problem with `summarise()` input `..1`.
#> x Problem with `across()` input `.fns`.
#> ℹ Input `.fns` must be NULL, a function, a formula, or a list of functions/formulas.
#> ℹ Input `..1` is `dplyr::across(...)`.
```

<sup>Created on 2021-01-30 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

This PR makes a robust fix by tunnelling the various argument names using the double braces `{{}}` as necessary. This means the tidy evaluation works appropriately and we no longer have to worry about what users name their columns. I've named `.data_col` back to `x` and `.data` back to `data`, as they were before.

To confirm the fix is robust, I've also added a test (also shown below) where I rename the columns of mtcars to all the argument names used in the function and check whether we still get the same result we would get with `correlate()`:

``` r
library(waldo)
library(corrr)

arg_names <- c("x", ".x", "f", ".f" , ".fns", "data", ".data",
               "summarise_col", ".cols", "diagonal", ".diagonal")

my_mtcars <- mtcars
colnames(my_mtcars) <- arg_names

compare(colpair_map(my_mtcars, cor),
        correlate(my_mtcars, quiet = TRUE),
        tolerance = 1e-10)
#> ✓ No differences
```

<sup>Created on 2021-01-30 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

