### PR TITLE
Fix typos in stretch.Rd examples

### DIFF
--- a/R/reshape.R
+++ b/R/reshape.R
@@ -111,10 +111,10 @@ focus_if.default <- function(x, .predicate, ..., mirror = FALSE) {
 #' @examples
 #' x <- correlate(mtcars)
 #' stretch(x)  # Convert all to long format
-#' stretch(x, na.rm = FALSE)  # omit NAs (diagonal in this case)
+#' stretch(x, na.rm = TRUE)  # omit NAs (diagonal in this case)
 #'
 #' x <- shave(x)  # use shave to set upper triangle to NA and then...
-#' stretch(x, na.rm = FALSE)  # omit all NAs, therefore keeping each
+#' stretch(x, na.rm = TRUE)  # omit all NAs, therefore keeping each
 #'                              # correlation only once.
 stretch <- function(x, na.rm = FALSE, remove.dups =  FALSE) {
   UseMethod("stretch")

--- a/man/stretch.Rd
+++ b/man/stretch.Rd
@@ -26,9 +26,9 @@ data frame. The term column is handled automatically.
 \examples{
 x <- correlate(mtcars)
 stretch(x)  # Convert all to long format
-stretch(x, na.rm = FALSE)  # omit NAs (diagonal in this case)
+stretch(x, na.rm = TRUE)  # omit NAs (diagonal in this case)
 
 x <- shave(x)  # use shave to set upper triangle to NA and then...
-stretch(x, na.rm = FALSE)  # omit all NAs, therefore keeping each
+stretch(x, na.rm = TRUE)  # omit all NAs, therefore keeping each
                              # correlation only once.
 }

--- a/man/stretch.Rd
+++ b/man/stretch.Rd
@@ -26,9 +26,9 @@ data frame. The term column is handled automatically.
 \examples{
 x <- correlate(mtcars)
 stretch(x)  # Convert all to long format
-stretch(x, na.rm = TRUE)  # omit NAs (diagonal in this case)
+stretch(x, na.rm = FALSE)  # omit NAs (diagonal in this case)
 
 x <- shave(x)  # use shave to set upper triangle to NA and then...
-stretch(x, na.rm = TRUE)  # omit all NAs, therefore keeping each
+stretch(x, na.rm = FALSE)  # omit all NAs, therefore keeping each
                              # correlation only once.
 }


### PR DESCRIPTION
I guess in the second and third example it should be ``na.rm = TRUE``.