### PR TITLE
casting noquote to character to avoid unnecessary rplot warning

### DIFF
--- a/R/cor_df.R
+++ b/R/cor_df.R
@@ -128,7 +128,7 @@ rplot.cor_df <- function(rdf,
   # Convert data to relevant format for plotting
   pd <- stretch(rdf, na.rm = TRUE)
   pd$size <- abs(pd$r)
-  pd$label <- fashion(pd$r)
+  pd$label <- as.character(fashion(pd$r))
 
   if (.order == "default") {
     pd$x <- factor(pd$x, levels = row_order)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ fashion(x)
 #> 8   wt -.87 -.71 -.69 -.58 -.17  .43  .66          
 #> 9 disp -.85 -.71 -.59 -.56 -.43  .39  .79  .89
 rplot(x)
-#> Don't know how to automatically pick scale for object of type noquote. Defaulting to continuous.
 ```
 
 ![](man/figures/README-combination-1.png)<!-- -->


### PR DESCRIPTION
In response to #153. 

Prior to this PR, the `rplot()` functions raises a warning that is unnecessary for the end user.