### PR TITLE
Merge into main

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 - `correlate()` now removes non-numeric columns from data frame inputs (@thisisdaryn, #139).
 - `autoplot.cor_df()` method have been added fot quick generation of correlation chart.
+- `network_plot()` now allows the user the option to map the color range to the range of correlations that are in the input `rdf` (@thisisdaryn, #158). 
 
 # corrr 0.4.3
 

--- a/R/cor_df.R
+++ b/R/cor_df.R
@@ -178,11 +178,13 @@ rplot.cor_df <- function(rdf,
 #' @export
 network_plot.cor_df <- function(rdf,
                                 min_cor = .30,
-                                legend = TRUE,
+                                legend = c("full", "range", "none"),
                                 colours = c("indianred2", "white", "skyblue1"),
                                 repel = TRUE,
                                 curved = TRUE,
                                 colors) {
+  legend <- rlang::arg_match(legend)
+
   if (min_cor < 0 || min_cor > 1) {
     rlang::abort("min_cor must be a value ranging from zero to one.")
   }
@@ -260,6 +262,13 @@ network_plot.cor_df <- function(rdf,
     }
   }
 
+  if(legend %in% c("full", "none")){
+    legend_range = c(-1, 1)
+  }
+  else if(legend == "range"){
+    legend_range = c(min(rdf[row(rdf)!=col(rdf)]),
+                     max(rdf[row(rdf)!=col(rdf)]))
+  }
   plot_ <- list(
     # For plotting paths
     if (curved) {
@@ -284,7 +293,7 @@ network_plot.cor_df <- function(rdf,
     },
     scale_alpha(limits = c(0, 1)),
     scale_size(limits = c(0, 1)),
-    scale_colour_gradientn(limits = c(-1, 1), colors = colours),
+    scale_colour_gradientn(limits = legend_range, colors = colours),
     # Plot the points
     geom_point(
       data = points,
@@ -322,8 +331,8 @@ network_plot.cor_df <- function(rdf,
     # Theme and legends
     theme_void(),
     guides(size = "none", alpha = "none"),
-    if (legend) labs(colour = NULL),
-    if (!legend) theme(legend.position = "none")
+    if (legend != "none") labs(colour = NULL),
+    if (legend == "none") theme(legend.position = "none")
   )
 
   ggplot() + plot_

--- a/R/output.R
+++ b/R/output.R
@@ -125,6 +125,10 @@ rplot.default <- function(rdf, ...) {
 #'
 #' @param min_cor Number from 0 to 1 indicating the minimum value of
 #'   correlations (in absolute terms) to plot.
+#' @param legend How should the colors and legend for the correlation values be
+#' displayed? The options are "full" (the default) for -1 to 1 with a legend,
+#' "range" for the range of correlation values in \code{rdf} with a legend,
+#' or "none" for colors between -1 to 1 with no legend displayed.
 #' @param colours,colors Vector of colors to use for n-color gradient.
 #' @param repel Should variable labels repel each other? If TRUE, text is added
 #'   via \code{\link[ggrepel]{geom_text_repel}} instead of \code{\link[ggplot2]{geom_text}}
@@ -141,7 +145,7 @@ rplot.default <- function(rdf, ...) {
 #' network_plot(x, min_cor = .7, colors = c("red", "green"), legend = TRUE)
 network_plot <- function(rdf,
                          min_cor = .3,
-                         legend = TRUE,
+                         legend = c("full", "range", "none"),
                          colours = c("indianred2", "white", "skyblue1"),
                          repel = TRUE,
                          curved = TRUE,

--- a/man/colpair_map.Rd
+++ b/man/colpair_map.Rd
@@ -28,10 +28,9 @@ of its columns. The result is a correlation data frame (see
 colpair_map(mtcars, cov)
 
 ## Function to get the p-value from a t-test:
-calc_p_value <- function(vec_a, vec_b){
+calc_p_value <- function(vec_a, vec_b) {
   t.test(vec_a, vec_b)$p.value
 }
 
 colpair_map(mtcars, calc_p_value)
-
 }

--- a/man/dice.Rd
+++ b/man/dice.Rd
@@ -17,5 +17,4 @@ Returns a correlation table with the selected fields only
 \examples{
 
 dice(correlate(mtcars), mpg, wt, am)
-
 }

--- a/man/focus.Rd
+++ b/man/focus.Rd
@@ -36,10 +36,10 @@ function, see \code{\link[dplyr]{select}}.
 \examples{
 library(dplyr)
 x <- correlate(mtcars)
-focus(x, mpg, cyl)  # Focus on correlations of mpg and cyl with all other variables
-focus(x, -disp, - mpg, mirror = TRUE)  # Remove disp and mpg from columns and rows
+focus(x, mpg, cyl) # Focus on correlations of mpg and cyl with all other variables
+focus(x, -disp, -mpg, mirror = TRUE) # Remove disp and mpg from columns and rows
 
 x <- correlate(iris[-5])
-focus(x, -matches("Sepal"))  # Focus on correlations of non-Sepal
-                             # variables with Sepal variables.
+focus(x, -matches("Sepal")) # Focus on correlations of non-Sepal
+# variables with Sepal variables.
 }

--- a/man/network_plot.Rd
+++ b/man/network_plot.Rd
@@ -7,7 +7,7 @@
 network_plot(
   rdf,
   min_cor = 0.3,
-  legend = TRUE,
+  legend = c("full", "range", "none"),
   colours = c("indianred2", "white", "skyblue1"),
   repel = TRUE,
   curved = TRUE,
@@ -21,8 +21,10 @@ that can be coerced to one (see \code{\link{as_cordf}}).}
 \item{min_cor}{Number from 0 to 1 indicating the minimum value of
 correlations (in absolute terms) to plot.}
 
-\item{legend}{Boolean indicating whether a legend mapping the colors to the
-correlations should be displayed.}
+\item{legend}{How should the colors and legend for the correlation values be
+displayed? The options are "full" (the default) for -1 to 1 with a legend,
+"range" for the range of correlation values in \code{rdf} with a legend,
+or "none" for colors between -1 to 1 with no legend displayed.}
 
 \item{colours, colors}{Vector of colors to use for n-color gradient.}
 

--- a/man/rearrange.Rd
+++ b/man/rearrange.Rd
@@ -27,6 +27,6 @@ together.
 x <- correlate(mtcars)
 
 rearrange(x) # Default settings
-rearrange(x, method = "HC")  # Different seriation method
-rearrange(x, absolute = FALSE)  # Not using absolute values for arranging
+rearrange(x, method = "HC") # Different seriation method
+rearrange(x, absolute = FALSE) # Not using absolute values for arranging
 }

--- a/man/shave.Rd
+++ b/man/shave.Rd
@@ -21,6 +21,6 @@ missing values.
 }
 \examples{
 x <- correlate(mtcars)
-shave(x)  # Default; shave upper triangle
-shave(x, upper = FALSE)  # shave lower triangle
+shave(x) # Default; shave upper triangle
+shave(x, upper = FALSE) # shave lower triangle
 }

--- a/man/stretch.Rd
+++ b/man/stretch.Rd
@@ -25,10 +25,10 @@ data frame. The term column is handled automatically.
 }
 \examples{
 x <- correlate(mtcars)
-stretch(x)  # Convert all to long format
-stretch(x, na.rm = TRUE)  # omit NAs (diagonal in this case)
+stretch(x) # Convert all to long format
+stretch(x, na.rm = TRUE) # omit NAs (diagonal in this case)
 
-x <- shave(x)  # use shave to set upper triangle to NA and then...
-stretch(x, na.rm = TRUE)  # omit all NAs, therefore keeping each
-                             # correlation only once.
+x <- shave(x) # use shave to set upper triangle to NA and then...
+stretch(x, na.rm = TRUE) # omit all NAs, therefore keeping each
+# correlation only once.
 }


### PR DESCRIPTION
network plot to map the color range to the range of correlations in data (#159)

* Adding an option for network plot to map the color range only to the range of correlations in the data and not to the full range from -1 to 1

* Adjust documentation for new options

* Update R/cor_df.R

Co-authored-by: Julia Silge <julia.silge@gmail.com>

Co-authored-by: Julia Silge <julia.silge@gmail.com>