### PR TITLE
167 abs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # corrr (development version)
 
+- `rearrange(absolute = TRUE)` works again (@jmbarbone, #167)
+
+- Extra `cor_df` classes are no longer appended to `cor_df` objects (@jmbarbone)
+
 # corrr 0.4.4
 
 - Make `colpair_map()` more robust to input column names, with the exception of ".data" and ".env" (@jameslairdsmith, #131).

--- a/R/cor_df.R
+++ b/R/cor_df.R
@@ -41,7 +41,9 @@ rearrange.cor_df <- function(x, method = "PCA", absolute = TRUE) {
   # Convert to original matrix
   m <- as_matrix(x, diagonal = 1)
 
-  if (absolute) abs(m)
+  if (absolute) {
+    m <- abs(m)
+  }
 
   if (method %in% c("BEA", "BEA_TSP", "PCA", "PCA_angle")) {
     ord <- seriation::seriate(m, method = method)

--- a/R/utility.R
+++ b/R/utility.R
@@ -36,7 +36,11 @@ new_cordf <- function(x, term = NULL) {
   if (!is.null(term)) {
     x <- first_col(x, term)
   }
-  class(x) <- c("cor_df", class(x))
+
+  if (!inherits(x, "cor_df")) {
+    class(x) <- c("cor_df", class(x))
+  }
+
   x
 }
 

--- a/tests/testthat/test-rearrange.R
+++ b/tests/testthat/test-rearrange.R
@@ -4,7 +4,29 @@ test_that("Rearrange return correct order", {
   d <- correlate(d)
 
   expect_equal(
-    colnames(rearrange(d)),
+    colnames(rearrange(d, absolute = FALSE)),
     c("term", "Petal.Length", "Petal.Width", "Sepal.Length", "Sepal.Width")
   )
+})
+
+test_that("rearrange(absolute) works again [#167]", {
+  df <- data.frame(
+    x = 1:10,
+    y = -c(1:10),
+    z = 1:10
+  )
+
+  x <- correlate(df, quiet = TRUE)
+  obj <- rearrange(x, absolute = FALSE)
+  exp <- as_cordf(tibble(
+    term = c("x", "z", "y"),
+    x = c(NA, 1, -1),
+    z = c(1, NA, -1),
+    y = c(-1, -1, NA)
+  ))
+  expect_identical(obj, exp)
+
+  # should not change the order
+  obj <- rearrange(x, absolute = TRUE)
+  expect_identical(obj, x)
 })

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -4,3 +4,9 @@ test_that("pair_n works", {
     "matrix"
   )
 })
+
+test_that("new_cordf() doesn't append again", {
+  x <- as_cordf(data.frame(a = 1))
+  obj <- new_cordf(x)
+  expect_identical(obj, x)
+})


### PR DESCRIPTION
resolves #167

I also found an issue with `new_cordf()` that appended extra `cor_df` classes to `cor_df` objects (called from `rearrange.cor_df()`).  Seemed fine to correct that.

- prevent extra cor_df classes
- reassign abs(m)
- add and correct tests
- update
