### PR TITLE
Better integration of package seriation

### DIFF
--- a/R/cor_df.R
+++ b/R/cor_df.R
@@ -36,17 +36,19 @@ shave.cor_df <- function(x, upper = TRUE) {
 }
 
 #' @export
-rearrange.cor_df <- function(x, method = "PCA", absolute = TRUE) {
+rearrange.cor_df <- function(x, method = "PCA", absolute = FALSE) {
 
   # Convert to original matrix
   m <- as_matrix(x, diagonal = 1)
 
-  if (absolute) abs(m)
+  if (absolute)
+    m <- abs(m)
 
-  if (method %in% c("BEA", "BEA_TSP", "PCA", "PCA_angle")) {
+  if (method %in% seriation::list_seriation_methods("matrix")) {
     ord <- seriation::seriate(m, method = method)
   } else {
-    ord <- seriation::seriate(dist(m), method = method)
+    #ord <- seriation::seriate(dist(m), method = method)
+    ord <- seriation::seriate(sqrt(stats::as.dist(1 - m)), method = method)
   }
 
   ord <- seriation::get_order(ord)

--- a/R/internal.R
+++ b/R/internal.R
@@ -22,19 +22,30 @@ shave <- function(x, upper = TRUE) {
 #' together.
 #'
 #' @param x cor_df. See \code{\link{correlate}}.
-#' @param method String specifying the arrangement (clustering) method.
-#'   Clustering is achieved via \code{\link[seriation]{seriate}}, which can be
+#' @param method String specifying the arrangement method.
+#'   Reordering is achieved via \code{\link[seriation]{seriate}}, which can be
 #'   consulted for a complete list of clustering methods. Default = "PCA".
 #' @param absolute Boolean whether absolute values for the correlations should
-#'   be used for clustering.
+#'   be used for reordering.
 #' @return cor_df. See \code{\link{correlate}}.
 #' @export
+#' @references
+#' Hahsler M, Hornik K, Buchta C (2008). "Getting things in order:
+#' An introduction to the R package seriation."
+#' Journal of Statistical Software, 25(3), 1-34. ISSN 1548-7660.
+#' \doi{10.18637/jss.v025.i03}
 #' @examples
 #' x <- correlate(mtcars)
 #'
-#' rearrange(x) # Default settings
-#' rearrange(x, method = "HC") # Different seriation method
-#' rearrange(x, absolute = FALSE) # Not using absolute values for arranging
+#' rearrange(x) # Default settings (PCA)
+#' rearrange(x, method = "PCA_angle") # Angle in 2D PCA projection
+#' rearrange(x, method = "OLO") # Optimal leaf ordering
+#' rearrange(x, method = "R2E") # Rank 2 ellipse seriation
+#'
+#' rearrange(x, absolute = TRUE) # Using absolute values for arranging
+#'
+#' # list all available seriation methods
+#' seriation::list_seriation_methods()
 rearrange <- function(x, method = "PC", absolute = TRUE) {
   UseMethod("rearrange")
 }


### PR DESCRIPTION
Hi Max, 

Here are a few suggested improvements for the integration of seriation into corrr:

* Updated the calculation of deltas (distances) based on correlations to the standard delta = sqrt(1 - corr).
* Fixed the unused absolute parameter (the return value of abs was not assigned). I think absolute = FALSE is the intended default value.
* All seriation methods can now be used. 
* Updated man page.

Best,
Michael